### PR TITLE
add: Prettierを導入し、コマンドでフォーマットを実行できるようにする（`'yocto-queue'`も導入）

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Ignore artifacts:
+build
+coverage
+
+# Ignore specific files:
+.github/PULL_REQUEST_TEMPLATE.md
+README.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": false,
+  "endOfLine": "auto",
+  "trailingComma": "none",
+  "bracketSpacing": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "react-dom": "^19.0.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "prettier": "3.5.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -13509,6 +13512,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-scripts": "5.0.1",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "yocto-queue": "^1.2.0"
       },
       "devDependencies": {
         "prettier": "3.5.3"
@@ -7708,6 +7709,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -13909,6 +13922,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-dev-utils/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
@@ -17543,12 +17568,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.0.tgz",
+      "integrity": "sha512-KHBC7z61OJeaMGnF3wqNZj+GGNXOyypZviiKpQeiHirG5Ib1ImwcLBH70rbMSkKfSmUNBsdf2PwaEJtKvgmkNw==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "yocto-queue": "^1.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "format": "prettier . --write"
   },
   "eslintConfig": {
     "extends": [
@@ -35,5 +36,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "prettier": "3.5.3"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,11 @@
-import './App.css';
+import "./App.css"
 
 function App() {
   return (
     <div>
       <h1>Hello World</h1>
     </div>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
+import React from "react"
+import ReactDOM from "react-dom/client"
+import App from "./App"
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"))
 root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-);
+)


### PR DESCRIPTION
# add: Prettierを導入し、コマンドでフォーマットを実行できるようにする（`'yocto-queue'`も導入）
**できるようになったこと**
- 以下のコマンドでフォーマットを実行できるようにした
  ```bash
  npm run format
  ```
**実装**（参考記事：[Prettier(パッケージ版)の導入,`.prettierrc`(ルール設定) / `.prettierignore`(無視設定)](https://qiita.com/kkrtech/items/6416517f04347b980f8e)）
- `package.json`・`package-lock.json`に追加
  - Prettierをインストール（[Prettier公式](https://prettier.io/docs/install)）
  - フォーマットを実行するコマンドを指定
  - `push`すると、プレビュー環境で以下のエラーが出たので 、`'yocto-queue'`を追記してインストールしました
    （`'yocto-queue'`というモジュールがインストールされてないのが問題のようです）
    [![Image from Gyazo](https://i.gyazo.com/06a4f75501717b7c3a8364d3b39837fe.png)](https://gyazo.com/06a4f75501717b7c3a8364d3b39837fe)
- `.prettierignore`を生成
  - `.github/PULL_REQUEST_TEMPLATE.md` `README.md`をフォーマット実行する範囲から除外
- `.prettierrc`を生成
  - フォーマットを実行する内容を記載