### PR TITLE
add: JSON_placeholder_APIからデータを取得

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,35 @@
+import React, { useState } from "react"
 import "./App.css"
 
 function App() {
+  const [data, setData] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const fetchPosts = async () => {
+    try {
+      const response = await fetch(`https://jsonplaceholder.typicode.com/posts`)
+      const result = await response.json() // Promiseを解決
+      setData(result)
+    } catch (error) {
+      console.error("エラーが発生しました:", error)
+    } finally {
+      setIsLoading(false) // データ取得が完了したらローディングを解除
+    }
+  }
+
+  // コンポーネントが初回レンダリングされたときにfetchPostsを呼び出す
+  if (data === null) {
+    fetchPosts() // 初回レンダリング時にデータを取得
+  }
+
+  if (isLoading) {
+    return <p>読み込み中...</p> // データ取得中はローディング表示
+  }
+
   return (
     <div>
       <h1>Hello World</h1>
+      <p>{data[0].title}</p>
     </div>
   )
 }


### PR DESCRIPTION
# add: JSON_placeholder_APIからデータを取得
**できるようになったこと**
- https://meteorite-or-lifespan.vercel.app/
- **変更前**
   [![Image from Gyazo](https://i.gyazo.com/111f4956c69613a49225c56245556d3b.png)](https://gyazo.com/111f4956c69613a49225c56245556d3b)
- **変更後**
  [![Image from Gyazo](https://i.gyazo.com/a72846bfd7af169e8458bb3b3fceee8a.png)](https://gyazo.com/a72846bfd7af169e8458bb3b3fceee8a)
____
**実装**
参考記事：[【React】API呼び出しをマスターしよう！初心者でもわかる非同期通信の基礎と実践](https://www.resumy.ai/posts/18832dcc-5f97-4b4d-9ae8-2d161bca922a)
- **[JSON_placeholder_API](https://jsonplaceholder.typicode.com/)のデータを取得**
  - `src/App.js`を編集
    - https://jsonplaceholder.typicode.com/posts の投稿１つ目のタイトルを取得